### PR TITLE
mention how to set global endianess in data types

### DIFF
--- a/pattern_language/core-language/data-types.md
+++ b/pattern_language/core-language/data-types.md
@@ -69,6 +69,8 @@ be double myDouble; // Big endian 64 bit double precision floating point
 s8 myInteger;       // Native endian 8 bit signed integer
 ```
 
+Refer to [the endianess pragma](preprocessor.md#endian) for setting the global endianess
+
 ### Literals
 
 Literals are fixed values representing a specific constant. The following literals are available:


### PR DESCRIPTION
Adds a link to the data types page to the endian pragma for setting it globally 