### PR TITLE
fix issues in variable-placement -> functions

### DIFF
--- a/pattern_language/core-language/expressions.md
+++ b/pattern_language/core-language/expressions.md
@@ -27,11 +27,11 @@
 | `a ^^ b`      | Boolean XOR                                                                   |
 | `a ? b : c`   | Ternary                                                                       |
 | `(a)`         | Parenthesis                                                                   |
-| `function(a)` | [Function](https://imhex.werwolv.net/docs/core\_language/functions.html) call |
+| `function(a)` | [Function](./functions.md) call |
 
 `a`, `b` and `c` can be any numeric literal or another expression.
 
-#### Type Operators
+### Type Operators
 
 Type Operators are operators that work on types. They can only be used on a variable, not on a mathematical expression.
 
@@ -51,7 +51,7 @@ Type Operators are operators that work on types. They can only be used on a vari
 | `addressof($)` | Base address of the loaded data |
 | `sizeof($)`    | Size of the loaded data         |
 
-#### String Operators
+### String Operators
 
 String operators are any operators acting on strings directly.
 
@@ -66,7 +66,7 @@ String operators are any operators acting on strings directly.
 | `a < b`        | Lexical less-than              |
 | `a <= b`       | Lexical less than-or-equals    |
 
-#### Member Access
+### Member Access
 
 Member access is the act of accessing members inside a struct, union or bitfield or referencing the index of an array to access its value.
 
@@ -79,7 +79,7 @@ Below the simplest operations are shown, however they may be concatinated and ex
 | `parent.var`    | Accessing a variable inside the parent struct or union of the current struct or union |
 | `this`          | Refering to the current pattern. Can only be used inside of a struct or union         |
 
-#### `$` Dollar Operator
+### `$` Dollar Operator
 
 The Dollar Operator is a special operator which expands to the current offset within the current pattern.
 
@@ -103,7 +103,7 @@ The dollar operator can also be used to access single bytes of the main data.
 std::print($[0]); // Prints the value of the byte at address 0x00
 ```
 
-#### Casting Operator
+### Casting Operator
 
 The cast operator changes the type of an expression into another.
 

--- a/pattern_language/core-language/expressions.md
+++ b/pattern_language/core-language/expressions.md
@@ -27,7 +27,7 @@
 | `a ^^ b`      | Boolean XOR                                                                   |
 | `a ? b : c`   | Ternary                                                                       |
 | `(a)`         | Parenthesis                                                                   |
-| `function(a)` | [Function](./functions.md) call |
+| `function(a)` | [Function](functions.md) call |
 
 `a`, `b` and `c` can be any numeric literal or another expression.
 

--- a/pattern_language/core-language/functions.md
+++ b/pattern_language/core-language/functions.md
@@ -40,7 +40,7 @@ The above function will print out all passed values in sequence by printing the 
 
 ### Default parameters
 
-Default parameters can be used to set a default value for parameters, if they weren provided when the functon got called.
+Default parameters can be used to set a default value for parameters, if they weren't provided when the functon got called.
 
 ```rust
 fn print_numbers(u32 a, u32 b, u32 c = 3, u32 d = 4) {
@@ -150,7 +150,7 @@ for (u8 i = 0, i < 10, i = i + 1) {
 
 ### Loop control flow statements
 
-Inside of loops, the `break` and `continue` keyword may be used to to control the execution flow inside the loop.
+Inside of loops, the `break` and `continue` keyword may be used to control the execution flow inside the loop.
 
 When a `break` statement is reached, the loop is terminated immediately and code flow continues after the loop. When a `continue` statement is reached, the current iteration is terminated immediately and code flow continues at the start of the loop again, checking the condition again.
 

--- a/pattern_language/core-language/variable-placement.md
+++ b/pattern_language/core-language/variable-placement.md
@@ -12,7 +12,7 @@ In order for the runtime to start decoding data, variables need to be placed som
 u32 myPlacedVariable @ 0x110;
 ```
 
-This creates a new unsigned 32 bit variable named `myPlacedVariable` and place it at address `0x110`.
+This creates a new unsigned 32 bit variable named `myPlacedVariable` and places it at address `0x110`.
 
 The runtime will now treat the 4 bytes starting at offset `0x110` as a u32 and decodes the bytes at this address accordingly.
 
@@ -24,7 +24,7 @@ Placing variables isn’t limited to just built-in types. All types, even custom
 
 ### Global variables
 
-Sometimes it’s necessary to store data globally while the pattern is running. For this global variables can be used. The syntax is the same as with placed variables but are missing the _@_ placement instruction at the end.
+Sometimes it’s necessary to store data globally while the pattern is running. For this global variables can be used. The syntax is the same as with placed variables but without the _@_ placement instruction at the end.
 
 ```rust
 u32 globalVariable;


### PR DESCRIPTION
fix typos/misc issues in the variable-placement, expressions, and functions doc pages

this also attempts to fix an issue with the expression page not having a "on this page" section