### PR TITLE
Documentation discoverability and clarifying the sound visualiser

### DIFF
--- a/imhex/README.md
+++ b/imhex/README.md
@@ -12,7 +12,7 @@ description: >-
 
 **Database Repo**: [https://github.com/WerWolv/ImHex-Patterns](https://github.com/WerWolv/ImHex-Patterns)
 
-**Documentation Repo**: [https://github.com/WerWolv/Documentation](https://github.com/WerWolv/Documentation)
+**Documentation Repo**: [https://github.com/WerWolv/Documentation](https://github.com/WerWolv/Documentation) under `imhex`
 
 
 

--- a/imhex/README.md
+++ b/imhex/README.md
@@ -12,6 +12,8 @@ description: >-
 
 **Database Repo**: [https://github.com/WerWolv/ImHex-Patterns](https://github.com/WerWolv/ImHex-Patterns)
 
+**Documentation Repo**: [https://github.com/WerWolv/Documentation](https://github.com/WerWolv/Documentation)
+
 
 
 #### Pattern Language

--- a/imhex/views/pattern-data.md
+++ b/imhex/views/pattern-data.md
@@ -76,7 +76,7 @@ This visualizer expects any pattern that contains raw RGBA8 values in the form o
 
 `[[hex::visualize("sound", pattern, num_channels, sample_rate)]]`
 
-This visualizer expects any pattern that contains all the bytes of a raw unsigned 16-bit PCM audio stream, the number of channels that are being used and the sample rate. It allows you to convert this data to sound to listen to.
+This visualizer expects any pattern that contains all the bytes of a raw signed 16-bit PCM audio stream, the number of channels that are being used and the sample rate. It allows you to convert this data to sound to listen to.
 
 <figure><img src="../.gitbook/assets/image (8).png" alt=""><figcaption><p>Sound Visualizer</p></figcaption></figure>
 

--- a/imhex/views/pattern-data.md
+++ b/imhex/views/pattern-data.md
@@ -76,7 +76,7 @@ This visualizer expects any pattern that contains raw RGBA8 values in the form o
 
 `[[hex::visualize("sound", pattern, num_channels, sample_rate)]]`
 
-This visualizer expects any pattern that contains all the bytes of a raw PCM audio stream, the number of channels that are being used and the sample rate. It allows you to convert this data to sound to listen to.
+This visualizer expects any pattern that contains all the bytes of a raw unsigned 16-bit PCM audio stream, the number of channels that are being used and the sample rate. It allows you to convert this data to sound to listen to.
 
 <figure><img src="../.gitbook/assets/image (8).png" alt=""><figcaption><p>Sound Visualizer</p></figcaption></figure>
 

--- a/pattern_language/README.md
+++ b/pattern_language/README.md
@@ -6,3 +6,5 @@ description: A custom C++ and Rust inspired scripting language for analyzing bin
 
 The Pattern Language is a C++ and Rust inspired DSL that was developed for the\
 [ImHex Hex Editor](https://app.gitbook.com/o/xfl3734L2rDBS2sD53Zi/s/xj7sbzGbHH260vbpZOu1/) to easily define and decode binary structures found in files or memory.
+
+If you want to contribute towards improving this documentation, the source documents are available at [https://github.com/WerWolv/Documentation](https://github.com/WerWolv/Documentation) under `pattern_language`.


### PR DESCRIPTION
I was looking through the source code of the sound visualiser to figure out how it behaved, and when I decided to contribute some clarifications to the docs I had a lot of trouble finding the source of the documentation.

The changes made in this pull request point the user to the source documents of the documentation for the pattern language and ImHex, and also make it clear that the sound visualiser interprets the pattern as a stream of signed 16-bit integers.

I'm not sure how the sound visualiser respects endianness, come to think of it. 