### PR TITLE
Replace get_attribute_value with get_attribute_argument, mark optional arguments

### DIFF
--- a/pattern_language/libraries/std/core.pat.md
+++ b/pattern_language/libraries/std/core.pat.md
@@ -83,15 +83,17 @@ Checks if a pattern has a specific attribute assigned to it
 fn has_attribute(auto pattern, str attribute);
 ```
 
-### `std::core::get_attribute_value`
+### `std::core::get_attribute_argument`
 
-Returns the first parameter of the attribute of a pattern if it has one
+Returns the nth parameter of the attribute of a pattern if it has one
 - `pattern`: The pattern to check
 - `attribute`: The attribute's name to query
+- `[index]`: The attribute's parameter index to get. Defaults to 0
 
 
 ```rust
-fn get_attribute_value(auto pattern, str attribute);
+fn get_attribute_attribute(auto pattern, str attribute);
+fn get_attribute_attribute(auto pattern, str attribute, u32 index);
 ```
 
 ### `std::core::set_endian`
@@ -113,22 +115,6 @@ Gets the current default endianess.
 
 ```rust
 fn get_endian();
-```
-
-### `std::core::set_bitfield_order`
-
-
-
-```rust
-fn set_bitfield_order(std::core::BitfieldOrder order);
-```
-
-### `std::core::get_bitfield_order`
-
-
-
-```rust
-fn get_bitfield_order();
 ```
 
 ### `std::core::array_index`

--- a/pattern_language/libraries/std/math.pat.md
+++ b/pattern_language/libraries/std/math.pat.md
@@ -462,13 +462,16 @@ Calculates the sum of all values in the specified memory range.
 - `start`: Start address
 - `end`: End address
 - `valueSize`: Size of each value in bytes
-- `section`: Section to use
-- `operation`: Operation to use
-- `endian`: Endianness to use
+- `[section]`: Section to use. Optional
+- `[operation]`: Operation to use. Defaults to addition
+- `[endian]`: Endianness to use. Defaults to native
 - `return`: Sum of all values in the specified memory range
 
 
 ```rust
+fn accumulate(u128 start, u128 end, u128 valueSize);
+fn accumulate(u128 start, u128 end, u128 valueSize, std::mem::Section section);
+fn accumulate(u128 start, u128 end, u128 valueSize, std::mem::Section section, std::math::AccumulateOperation operation);
 fn accumulate(u128 start, u128 end, u128 valueSize, std::mem::Section section, std::math::AccumulateOperation operation, std::mem::Endian endian);
 ```
 

--- a/pattern_language/libraries/std/mem.pat.md
+++ b/pattern_language/libraries/std/mem.pat.md
@@ -134,11 +134,12 @@ fn find_sequence_in_range(u128 occurrence_index, u128 offsetFrom, u128 offsetTo,
 Reads a unsigned value from the memory
 - `address`: The address to read from
 - `size`: The size of the value to read
-- `endian`: The endianess of the value to read
+- `[endian]`: The endianess of the value to read. Defaults to native
 - `return`: The value read
 
 
 ```rust
+fn read_unsigned(u128 address, u8 size);
 fn read_unsigned(u128 address, u8 size, std::mem::Endian endian);
 ```
 
@@ -147,11 +148,12 @@ fn read_unsigned(u128 address, u8 size, std::mem::Endian endian);
 Reads a signed value from the memory
 - `address`: The address to read from
 - `size`: The size of the value to read
-- `endian`: The endianess of the value to read
+- `[endian]`: The endianess of the value to read. Defaults to native
 - `return`: The value read
 
 
 ```rust
+fn read_signed(u128 address, u8 size);
 fn read_signed(u128 address, u8 size, std::mem::Endian endian);
 ```
 

--- a/pattern_language/libraries/std/random.pat.md
+++ b/pattern_language/libraries/std/random.pat.md
@@ -66,22 +66,26 @@ The random number generator used internally is C++'s std::mt19937_64 Mersenne Tw
 > - `Poisson(mean) -> i128`
 
 - `distribution`: Distribution to use
-- `param1`: This parameter depends on the type of distribution used.
-- `param2`: This parameter depends on the type of distribution used.
+- `[param1]`: This parameter depends on the type of distribution used. Defaults to 0
+- `[param2]`: This parameter depends on the type of distribution used. Defaults to 0
 
 
 ```rust
+fn generate_using(std::random::Distribution distribution);
+fn generate_using(std::random::Distribution distribution, auto param1);
 fn generate_using(std::random::Distribution distribution, auto param1, auto param2);
 ```
 
 ### `std::random::generate`
 
 Generates a uniformly distributed random number between `min` and `max`
-- `min`: Minimum number
-- `max`: Maximum number
+- `[min]`: Minimum number. Defaults to 0
+- `[max]`: Maximum number. Defaults to `u64_max`
 
 
 ```rust
+fn generate();
+fn generate(u64 min);
 fn generate(u64 min, u64 max);
 ```
 

--- a/pattern_language/libraries/std/time.pat.md
+++ b/pattern_language/libraries/std/time.pat.md
@@ -88,11 +88,12 @@ fn to_utc(std::time::EpochTime epoch_time);
 ### `std::time::now`
 
 Queries the current time in the specified time zone.
-- `time_zone`: The time zone to query.
+- `[time_zone]`: The time zone to query. Defaults to local.
 - `return`: The current time in the specified time zone.
 
 
 ```rust
+fn now();
 fn now(std::time::TimeZone time_zone);
 ```
 
@@ -133,11 +134,12 @@ fn filetime_to_unix(u64 value);
 
 Formats a time according to the specified format string.
 - `time`: The time to format.
-- `format_string`: The format string to use.
+- `[format_string]`: The format string to use. Defaults to "%c".
 - `return`: The formatted time.
 
 
 ```rust
+fn format(std::time::Time time);
 fn format(std::time::Time time, str format_string);
 ```
 
@@ -145,11 +147,12 @@ fn format(std::time::Time time, str format_string);
 
 Formats a DOS date according to the specified format string.
 - `date`: The DOS date to format.
-- `format_string`: The format string to use.
+- `[format_string]`: The format string to use. Defaults to "{}/{}/{}".
 - `return`: The formatted DOS date.
 
 
 ```rust
+fn format_dos_date(std::time::DOSDate date);
 fn format_dos_date(std::time::DOSDate date, str format_string);
 ```
 
@@ -157,11 +160,12 @@ fn format_dos_date(std::time::DOSDate date, str format_string);
 
 Formats a DOS time according to the specified format string.
 - `time`: The DOS time to format.
-- `format_string`: The format string to use.
+- `[format_string]`: The format string to use. Defaults to "{:02}:{:02}:{:02}".
 - `return`: The formatted DOS time.
 
 
 ```rust
+fn format_dos_time(std::time::DOSTime time);
 fn format_dos_time(std::time::DOSTime time, str format_string);
 ```
 


### PR DESCRIPTION
This pull request replaces `std::core::get_attribute_value` with `std::core::get_attribute_argument`, to correspond with https://github.com/WerWolv/ImHex-Patterns/pull/233.
In the process, I also removed the `std::core::get_bitfield_order` and `std::core::set_bitfield_order` functions from the documentation, which were removed in early 2023.

Lastly, library functions with optional arguments now have square brackets around those arguments and list their default values, and the function lines have one duplicate for each "optional-variation". For example:
```rust
fn generate();
fn generate(u64 min);
fn generate(u64 min, u64 max);
```
(The single-line alternative would be `fn generate([u64 min, [u64 max]]);`. Some people would prefer that, others would prefer the more "at a glance"-like approach of the multiple function lines above.)