### PR TITLE
Add example and explanation for reopening nested namespaces

### DIFF
--- a/pattern_language/core-language/namespaces.md
+++ b/pattern_language/core-language/namespaces.md
@@ -22,3 +22,37 @@ Type type2 @ 0x200;
 ```
 
 To access a type within a namespace, the scope resolution operator `::` is used. In the example above, to access the type `Type` inside the namespace `abc`, `abc::Type` is used.
+
+## Nested and Reopened Namespaces
+
+You can also define **nested namespaces** and reopen them later. This is especially useful for organizing internal constants and helper logic related to the main types, while keeping them encapsulated.
+
+```cpp
+namespace game {
+
+    struct User {
+        u32 id;
+        u32 age;
+    } [[format("game::impl::format_user")]];
+
+    namespace impl {
+        fn format_user(User user) {
+            return std::format("User({}, {})", user.id, user.age);
+        };
+    }
+
+    struct Score {
+        u32 points;
+        u32 level;
+    } [[format("game::impl::format_score")]];
+
+    namespace impl {
+        fn format_score(Score score) {
+            return std::format("Score({}, {})", score.points, score.level);
+        };
+    }
+
+}
+```
+
+These separate blocks both add to the same `game::impl` namespace. This provides a clean separation between public type definitions and internal helper logic and improves readablity.


### PR DESCRIPTION
- Demonstrated how to define the same nested namespace (e.g., `impl`) multiple times inside a parent namespace
- Added example using `User` and `Score` structs with associated `format_` functions
- Explained that this improves separation of logic and readability in large format definitions