### PR TITLE
Document `typenameof`

### DIFF
--- a/pattern_language/core-language/expressions.md
+++ b/pattern_language/core-language/expressions.md
@@ -35,10 +35,11 @@
 
 Type Operators are operators that work on types. They can only be used on a variable, not on a mathematical expression.
 
-| Operator       | Description         |
-| -------------- | ------------------- |
-| `addressof(a)` | Address of variable |
-| `sizeof(a)`    | Size of variable    |
+| Operator        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `addressof(a)`  | Address of variable                          |
+| `sizeof(a)`     | Size of variable                             |
+| `typenameof(a)` | String representation of the variable's type |
 
 `a` can be a variable, either by naming it directly or finding it through member access
 


### PR DESCRIPTION
Resolves #20.

A note: this PR doesn't address Paxcut's suggestion for the new behavior of `typenameof($)`. 