### PR TITLE
PatternLanguage - Adding more examples

### DIFF
--- a/pattern_language/README.md
+++ b/pattern_language/README.md
@@ -7,4 +7,102 @@ description: A custom C++ and Rust inspired scripting language for analyzing bin
 The Pattern Language is a C++ and Rust inspired DSL that was developed for the\
 [ImHex Hex Editor](https://app.gitbook.com/o/xfl3734L2rDBS2sD53Zi/s/xj7sbzGbHH260vbpZOu1/) to easily define and decode binary structures found in files or memory.
 
+# Getting Started
+
+Before diving into the documentation, let's start with a simple example.
+
+We have a file that follows this specification:
+
+| Offset | Type                  | Description          |
+| ------ | --------------------- | -------------------- |
+| 0x00   | uint                  | Animation count      |
+| 0x04   | uint[count]           | Offset of each entry |
+| ...    | AnimationEntry[count] | Animation entries    |
+
+We start with a minimal definition and refine it step by step.
+
+First, the basic structure. The file starts at 0x0, and the first 4 bytes are the number of animations in the file (`count`). 
+
+```rust
+struct AnimationBank {
+    u32 count;
+};
+
+AnimationBank animationBank @ 0x0;
+```
+
+Now that we know how many animations the file contains, we can define an array to store them.
+
+```rust
+struct Animation {
+};
+
+struct AnimationBank {
+    u32 count;
+    Animation animations[count];
+};
+
+AnimationBank animationBank @ 0x0;
+```
+
+Each Animation struct contains an offset, which defines the position of the AnimationEntry data:
+
+```rust
+struct Animation {
+    u32 offset;
+};
+
+struct AnimationBank {
+    u32 count;
+    Animation animations[count];
+};
+
+AnimationBank animationBank @ 0x0;
+```
+
+Each Animation points to a list of AnimationEntries located elsewhere in the file. We want to access these locations through the offset, and then read the AnimationEntry `count` times. This uses the [parent accessor](./core-language/expressions.md#member-access) to get the `count` variable.
+
+```rust
+struct AnimationEntry {
+};
+
+struct Animation {
+    u32 offset;
+    AnimationEntry entries[parent.count] @ offset;
+};
+
+struct AnimationBank {
+    u32 count;
+    Animation animations[count];
+};
+
+AnimationBank animationBank @ 0x0;
+```
+
+With the offsets and entry array in place, we can now define the actual contents of an AnimationEntry:
+
+```rust
+struct AnimationEntry {
+    u8 index;
+    u8 delay;
+    u8 flags;
+    u8 paletteIndex; 
+};
+
+struct Animation {
+    u32 offset;
+    AnimationEntry entries[parent.count] @ offset;
+};
+
+struct AnimationBank {
+    u32 count;
+    Animation animations[count];
+};
+
+AnimationBank animationBank @ 0x0;
+```
+
+# Contributing
+
 If you want to contribute towards improving this documentation, the source documents are available at [https://github.com/WerWolv/Documentation](https://github.com/WerWolv/Documentation) under `pattern_language`.
+

--- a/pattern_language/README.md
+++ b/pattern_language/README.md
@@ -45,7 +45,7 @@ struct AnimationBank {
 AnimationBank animationBank @ 0x0;
 ```
 
-Each Animation struct contains an offset, which defines the position of the AnimationEntry data:
+Each Animation struct contains an offset, which defines the position of the AnimationEntry:
 
 ```rust
 struct Animation {
@@ -60,7 +60,7 @@ struct AnimationBank {
 AnimationBank animationBank @ 0x0;
 ```
 
-Each Animation points to a list of AnimationEntries located elsewhere in the file. We want to access these locations through the offset, and then read the AnimationEntry `count` times. This uses the [parent accessor](./core-language/expressions.md#member-access) to get the `count` variable.
+Through this offsets, we can read each AnimationEntry:
 
 ```rust
 struct AnimationEntry {
@@ -68,7 +68,7 @@ struct AnimationEntry {
 
 struct Animation {
     u32 offset;
-    AnimationEntry entries[parent.count] @ offset;
+    AnimationEntry entry @ offset;
 };
 
 struct AnimationBank {
@@ -79,7 +79,7 @@ struct AnimationBank {
 AnimationBank animationBank @ 0x0;
 ```
 
-With the offsets and entry array in place, we can now define the actual contents of an AnimationEntry:
+With the offsets and entry in place, we can now define the actual contents of an AnimationEntry:
 
 ```rust
 struct AnimationEntry {

--- a/pattern_language/core-language/control-flow.md
+++ b/pattern_language/core-language/control-flow.md
@@ -119,6 +119,27 @@ struct Packet {
 Packet packet[3] @ 0xF0;
 ```
 
+The match options can also be multi-line:
+
+```rust
+struct Packet {
+  Type type;
+  u8 size;
+  bool isValid = false;
+
+  match (type, size) {
+    (Type::A, 0x200): {
+        PacketA packet;
+        isValid = true;
+    }
+    (Type::C, 0x100 | 0x200): PacketC packet;
+    (Type::B, 0x100 ... 0x300): PacketB packet;
+  }
+};
+
+Packet packet[3] @ 0xF0;
+```
+
 ### Pattern control flow
 
 The most basic form of conditional parsing are array control flow statements, `break` and `continue`. These allow you to stop the parsing of the array or skip elements based on conditions in the currently parsed item instance.

--- a/pattern_language/core-language/data-types.md
+++ b/pattern_language/core-language/data-types.md
@@ -147,6 +147,24 @@ Sometimes arrays need to keep on growing as long as a certain condition is met. 
 u8 string[while(std::mem::read_unsigned($, 1) != 0xFF)] @ 0x00;
 ```
 
+It's specially useful to combine it with the [break statement](./control-flow.md#break):
+
+```rust
+struct Segment {
+    u8 width, height, x, y;
+    u16 endFlag; // 0x01 if it's the last segment
+
+    if (endFlag == 0x01) {
+        break;
+    }
+};
+
+struct Sprite {
+    u32 id;
+    Segment segments[while(true)];
+};
+```
+
 #### Optimized arrays
 
 Big arrays take a long time to compute and take up a lot of memory. Because of this, arrays of built-in types are automatically optimized to only create one instance of the array type and move it around accordingly.

--- a/pattern_language/core-language/data-types.md
+++ b/pattern_language/core-language/data-types.md
@@ -412,3 +412,12 @@ struct MyType {
     float localVariable = 0.5; // Local variable
 };
 ```
+
+If you want them to show up, you need to use the [export attribute](./attributes.md#export):
+
+```rust
+struct MyType {
+    u32 x, y, z; // Regular members
+    float localVariable = 0.5 [[export]]; // This will appear in the Pattern Data view, similar to the regular members.
+};
+```

--- a/pattern_language/core-language/expressions.md
+++ b/pattern_language/core-language/expressions.md
@@ -121,6 +121,32 @@ The dollar operator can also be used to access single bytes of the main data.
 std::print($[0]); // Prints the value of the byte at address 0x00
 ```
 
+You can store it in a [global variable](./variable-placement.md#global-variables) and access it later:
+
+```rust
+
+u32 readLaterOffset;
+
+struct Header {
+    u32 id;
+    u32 bodyOffset;
+    readLaterOffset = $; 
+};
+
+struct Body {
+    u32 name;
+    u32 type;
+    u32 data[4] @ readLaterOffset;
+};
+
+struct Main {
+    Header header;
+    Body body @ header.bodyOffset;
+};
+
+Main main @ 0x0;
+```
+
 ### Casting Operator
 
 The cast operator changes the type of an expression into another.

--- a/pattern_language/core-language/functions.md
+++ b/pattern_language/core-language/functions.md
@@ -151,24 +151,23 @@ while (check()) {
 }
 ```
 
-They are specially useful when combined with [arrays](./data-types.md#loop-sized-array) and [global variables](./variable-placement.md#global-variables):
+Example: 
 
 ```rust
-bool is_last_segment = false;
+    fn getSum(u32 offset) {
+        u32 sum = 0;
+        while (offset <= 0x7A) {
+            offset +=1;
+            sum += std::mem::read_unsigned(offset, 1);
+        }
+        
+        return sum;
+    };
 
-struct Segment {
-    u8 width, height, x, y;
-    u16 endFlag; // 1 if it's the last segment
-
-    if (endFlag == 0x01) {
-        is_last_segment = true;
-    }
-};
-
-struct Sprite {
-    u32 id;
-    Segment segments[while(!is_last_segment)]; // 
-};
+    struct Loop {
+        u32 offset;
+        u32 sum = getSum(offset) [[export]];
+    };
 ```
 
 #### For-Loops

--- a/pattern_language/core-language/functions.md
+++ b/pattern_language/core-language/functions.md
@@ -139,6 +139,8 @@ if (x > 5) {
 }
 ```
 
+Check the [Conditionals section](./control-flow.md#conditionals) for more info.
+
 #### While-Loops
 
 While loops work similarly to if statements. As long as the condition in the head evaluates to true, the body will continuously be executed.

--- a/pattern_language/core-language/functions.md
+++ b/pattern_language/core-language/functions.md
@@ -149,6 +149,26 @@ while (check()) {
 }
 ```
 
+They are specially useful when combined with [arrays](./data-types.md#loop-sized-array) and [global variables](./variable-placement.md#global-variables):
+
+```rust
+bool is_last_segment = false;
+
+struct Segment {
+    u8 width, height, x, y;
+    u16 endFlag; // 1 if it's the last segment
+
+    if (endFlag == 0x01) {
+        is_last_segment = true;
+    }
+};
+
+struct Sprite {
+    u32 id;
+    Segment segments[while(!is_last_segment)]; // 
+};
+```
+
 #### For-Loops
 
 For loops are another kind of loop similar to the while loop. Its head consists of three blocks (ex. `i < 10`) that are separated by commas.

--- a/pattern_language/core-language/preprocessor.md
+++ b/pattern_language/core-language/preprocessor.md
@@ -125,3 +125,21 @@ This pragma specifies the pattern author shown in the [Content Store](../../imhe
 **Possible values:** Any string value **Default:** `Unspecified`
 
 This pragma specifies the description shown for the pattern in the [Content Store](../../imhex/misc/content-store.md).
+
+#### `allow_edits`
+
+This pragma allows to modify values that have already been loaded in memory. Replacing the actual binary data.
+
+Example:
+
+```rust
+#pragma allow_edits
+
+Struct Foo {
+    u8 firstByte; // 0x01
+    u8 secondByte; // 0x02
+    secondByte = 0x04; // This will replace 0x02 with the new value of 0x04
+};
+
+Foo f @ 0x0;
+```

--- a/pattern_language/core-language/variable-placement.md
+++ b/pattern_language/core-language/variable-placement.md
@@ -33,7 +33,7 @@ u32 globalVariable;
 Let's see an example:
 
 ```rust
-u8 lastValue;
+u8 lastValue; // A global variable
 
 fn setLastValue(u8 value) {
     lastValue = value;

--- a/pattern_language/core-language/variable-placement.md
+++ b/pattern_language/core-language/variable-placement.md
@@ -30,6 +30,24 @@ Sometimes it’s necessary to store data globally while the pattern is running. 
 u32 globalVariable;
 ```
 
+Let's see an example:
+
+```rust
+u8 lastValue;
+
+fn setLastValue(u8 value) {
+    lastValue = value;
+};
+
+struct Test {
+    u8 value;
+	
+    setLastValue(value);
+}; 
+
+Test test[10] @ 0x00;
+```
+
 ### Calculated pointers
 
 The same placement syntax may also be used inside of structs to specify where patterns are supposed to be placed in memory. These variables do not contribute to the overall size of the struct they are placed within.


### PR DESCRIPTION
Hey! I've been learning the Pattern Language for the last week and I wanted to add some examples in the documentation.

Most of these things are already documented, but for a new user it's not always easy to link concepts, specially if there are no examples (the [While](https://docs.werwolv.net/pattern-language/core-language/functions#while-loops) section is a great example of what I'm talking about). I had to dive into the Patterns to learn, and in my opinion, with these quick changes the learning curve will decrease.

I also read the Discussions to find questions that could be added to the docs. 

Looking for feedback :)

Thanks!