### PR TITLE
mem: copy_section_to_section() from_section == null

### DIFF
--- a/pattern_language/libraries/std/mem.pat.md
+++ b/pattern_language/libraries/std/mem.pat.md
@@ -263,7 +263,7 @@ fn set_section_size(std::mem::Section section,  size);
 ### `std::mem::copy_section_to_section`
 
 Copies a range of bytes from one section into another
-- `from_section`: The section to copy from
+- `from_section`: The section to copy from (`null` represents the main section)
 - `from_address`: The address to copy from
 - `to_section`: The section to copy to
 - `to_address`: The address to copy to


### PR DESCRIPTION
Document that `null` passed into `copy_section_to_section()` as the from_section parameter represents the `main` section. Discovered by reading `patterns/msf.hexpat` and subsequent testing.